### PR TITLE
fix(repository.pug): fix issue when using protocols !== https

### DIFF
--- a/views/repository/repository.pug
+++ b/views/repository/repository.pug
@@ -1,7 +1,9 @@
 block content
   - const colors = ['blue', 'azure', 'indigo', 'purple', 'pink', 'red', 'orange', 'yellow', 'lime', 'green', 'teal', 'cyan', 'gray', 'gray']
   - const random = (_) => colors[colors.length * Math.random() | 0]
-  - const domain = (url) => url.match(/^https?\:\/\/([^\/?#]+)(?:[\/?#]|$)/i)[1]
+  - const protocols = ['https', 'http', 'redis', 'rediss', 'ssh', 'udp', 'app']
+  - const regex = new RegExp(`^(${protocols.join('|')})?\:\/\/([^\/?#]+)(?:[\/?#]|$)`, 'i')
+  - const domain = (url) => url.match(regex)[1]
   - const initials = (name) => {
   -   result = name.match(/\b\w/g) || []
   -   return (result.shift() || '') + (result.pop() || '')


### PR DESCRIPTION
When other protocols are used, which is the case for applications that have production environments in GAE with the URI app protocol, or projects that publish their redis environment using the `redis` protocol, the view for a repository crashes, since it only supports https protocols.

This fix allows for other protocols to be supported, it's a simple list of the following:

`['https', 'http', 'redis', 'rediss', 'ssh', 'udp', 'app']`